### PR TITLE
Add cause to Heuristic exceptions to propagate original cause

### DIFF
--- a/public/transactions-api/src/main/java/com/atomikos/icatch/HeurCommitException.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/HeurCommitException.java
@@ -19,5 +19,9 @@ public class HeurCommitException extends HeuristicException {
 	public HeurCommitException() {
 		super("Heuristic Commit Exception");
 	}
+	
+	public HeurCommitException(Throwable cause) {
+		super("Heuristic Commit Exception", cause);
+	}
 
 }

--- a/public/transactions-api/src/main/java/com/atomikos/icatch/HeurHazardException.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/HeurHazardException.java
@@ -24,5 +24,13 @@ public class HeurHazardException extends HeuristicException {
 	public HeurHazardException(String msg) {
 		super(msg);
 	}
+	
+	public HeurHazardException(Throwable cause) {
+		super("Heuristic Hazard Exception", cause);
+	}
+
+	public HeurHazardException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
 
 }

--- a/public/transactions-api/src/main/java/com/atomikos/icatch/HeurMixedException.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/HeurMixedException.java
@@ -32,4 +32,8 @@ public class HeurMixedException extends HeuristicException
     {
         super("Heuristic Mixed Exception");
     }
+	
+	public HeurMixedException(Throwable cause) {
+		super("Heuristic Mixed Exception", cause);
+	}
 }

--- a/public/transactions-api/src/main/java/com/atomikos/icatch/HeurRollbackException.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/HeurRollbackException.java
@@ -20,5 +20,9 @@ public class HeurRollbackException extends HeuristicException {
 	public HeurRollbackException() {
 		super("Heuristic Rollback Exception");
 	}
+	
+	public HeurRollbackException(Throwable cause) {
+		super("Heuristic Rollback Exception", cause);
+	}
 
 }

--- a/public/transactions-api/src/main/java/com/atomikos/icatch/HeuristicException.java
+++ b/public/transactions-api/src/main/java/com/atomikos/icatch/HeuristicException.java
@@ -20,4 +20,8 @@ public class HeuristicException extends Exception {
 		super(message);
 	}
 	
+	public HeuristicException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
 }

--- a/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXAParticipant.java
+++ b/public/transactions-jdbc/src/main/java/com/atomikos/jdbc/nonxa/AtomikosNonXAParticipant.java
@@ -123,7 +123,7 @@ class AtomikosNonXAParticipant implements Participant, Serializable
                  LOGGER.logError ( "Error in non-XA commit", e );
                  //see case 30752: don't throw HAZARD because retries are probably useless
                  //and the connection won't be reused by the pool but destroyed instead
-                 throw new HeurMixedException();
+                 throw new HeurMixedException(e);
              }
         }
     }
@@ -148,7 +148,7 @@ class AtomikosNonXAParticipant implements Participant, Serializable
                 LOGGER.logError ( "Error in non-XA rollback", e );
                 //see case 30752: don't throw HAZARD because retries are probably useless
                 //and the connection won't be reused by the pool but destroyed instead
-                throw new HeurMixedException();
+                throw new HeurMixedException(e);
             }
         }
     }

--- a/public/transactions-jta/src/main/java/com/atomikos/datasource/xa/XAResourceTransaction.java
+++ b/public/transactions-jta/src/main/java/com/atomikos/datasource/xa/XAResourceTransaction.java
@@ -388,7 +388,7 @@ public class XAResourceTransaction implements ResourceTransaction, Participant {
 			LOGGER.logWarning(msg, xaerr); // see case 84253
 			if (XAException.XA_RBBASE <= xaerr.errorCode
 					&& xaerr.errorCode <= XAException.XA_RBEND) {
-				throw new RollbackException(msg);
+				throw new RollbackException(msg, xaerr);
 			} else {
 				LOGGER.logError(msg, xaerr);
 				throw new SysException(msg, xaerr);
@@ -474,13 +474,13 @@ public class XAResourceTransaction implements ResourceTransaction, Participant {
 				switch (xaerr.errorCode) {
 				case XAException.XA_HEURHAZ:
 					setState(TxState.HEUR_HAZARD);
-					throw new HeurHazardException();
+					throw new HeurHazardException(xaerr);
 				case XAException.XA_HEURMIX:
 					setState(TxState.HEUR_MIXED);
-					throw new HeurMixedException();
+					throw new HeurMixedException(xaerr);
 				case XAException.XA_HEURCOM:
 					setState(TxState.HEUR_COMMITTED);
-					throw new HeurCommitException();
+					throw new HeurCommitException(xaerr);
 				case XAException.XA_HEURRB:
 					forget();
 					break;
@@ -538,7 +538,7 @@ public class XAResourceTransaction implements ResourceTransaction, Participant {
 			// happens if already rolled back or something else;
 			// in any case the transaction can be trusted to act
 			// as if rollback already happened
-			throw new com.atomikos.icatch.RollbackException(re.getMessage());
+			throw new com.atomikos.icatch.RollbackException(re.getMessage(), re);
 		}
 
 		if (!(this.state.isOneOf(TxState.LOCALLY_DONE, TxState.IN_DOUBT, TxState.HEUR_HAZARD)))
@@ -565,21 +565,21 @@ public class XAResourceTransaction implements ResourceTransaction, Participant {
 					throw new SysException(msg, xaerr);
 				else
 					throw new com.atomikos.icatch.RollbackException(
-							"Already rolled back in resource.");
+							"Already rolled back in resource.", xaerr);
 			} else {
 				switch (xaerr.errorCode) {
 				case XAException.XA_HEURHAZ:
 					setState(TxState.HEUR_HAZARD);
-					throw new HeurHazardException();
+					throw new HeurHazardException(xaerr);
 				case XAException.XA_HEURMIX:
 					setState(TxState.HEUR_MIXED);
-					throw new HeurMixedException();
+					throw new HeurMixedException(xaerr);
 				case XAException.XA_HEURCOM:
 					forget();
 					break;
 				case XAException.XA_HEURRB:
 					setState(TxState.HEUR_ABORTED);
-					throw new HeurRollbackException();
+					throw new HeurRollbackException(xaerr);
 				case XAException.XAER_NOTA:
 					if (!onePhase) {
 						// see case 21552

--- a/public/transactions-tcc-rest/src/main/java/com/atomikos/icatch/tcc/rest/ParticipantAdapterImp.java
+++ b/public/transactions-tcc-rest/src/main/java/com/atomikos/icatch/tcc/rest/ParticipantAdapterImp.java
@@ -51,7 +51,7 @@ public class ParticipantAdapterImp implements ParticipantAdapter {
 
 		} catch (WebApplicationException e) {
 			if (e.getResponse().getStatus() == 404) {
-				throw new HeurRollbackException();
+				throw new HeurRollbackException(e);
 			} else {
 				throw e;
 			}

--- a/public/transactions/src/main/java/com/atomikos/icatch/imp/ActiveStateHandler.java
+++ b/public/transactions/src/main/java/com/atomikos/icatch/imp/ActiveStateHandler.java
@@ -127,7 +127,7 @@ class ActiveStateHandler extends CoordinatorStateHandler
 					}});
 
             } catch ( HeurCommitException hc ) {
-                throw new HeurMixedException();
+                throw new HeurMixedException(hc);
             }
 
             throw new RollbackException ( "Orphans detected." );
@@ -151,7 +151,7 @@ class ActiveStateHandler extends CoordinatorStateHandler
 					throw new RollbackException ( msg , error);
         		} catch ( HeurCommitException e ) {
 					LOGGER.logError ( "Illegal heuristic commit during rollback before prepare:" + e );
-					throw new HeurMixedException();
+					throw new HeurMixedException(e);
 				}
         	}
             count = participants.size ();

--- a/public/transactions/src/main/java/com/atomikos/icatch/imp/CommitMessage.java
+++ b/public/transactions/src/main/java/com/atomikos/icatch/imp/CommitMessage.java
@@ -63,7 +63,7 @@ class CommitMessage extends PropagationMessage
             // of participant proxies.
             String msg = "Unexpected error in commit";
             LOGGER.logError ( msg, e );
-            HeurHazardException heurh = new HeurHazardException();
+            HeurHazardException heurh = new HeurHazardException(e);
             throw new PropagationException ( heurh, true );
         }
     }

--- a/public/transactions/src/main/java/com/atomikos/icatch/imp/RollbackMessage.java
+++ b/public/transactions/src/main/java/com/atomikos/icatch/imp/RollbackMessage.java
@@ -57,7 +57,7 @@ class RollbackMessage extends PropagationMessage
             if ( indoubt_ ) {
                 // here, participant might be indoubt!
                 // fill in exact heuristic msgs by using buffered effect of proxies
-                HeurHazardException heurh = new HeurHazardException();
+                HeurHazardException heurh = new HeurHazardException(e);
                 throw new PropagationException ( heurh, true );
             }
         }


### PR DESCRIPTION
Add constructor with cause to Heuristic exceptions implementation to save original cause.
Always establish cause for these exceptions.